### PR TITLE
Parse expiration time as seconds

### DIFF
--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -14,7 +14,7 @@ class Verifier {
   constructor(body, claim, options = {}) {
     this.body = body;
     this.options = options;
-    this.time = Date.now();
+    this.time = Date.parse(new Date()) / 1000;
 
     this[`verify_${claim}`]();
   }

--- a/tests/verifier.spec.js
+++ b/tests/verifier.spec.js
@@ -7,9 +7,9 @@ describe('Claims', () => {
   let pastTime;
 
   beforeEach(() => {
-    currentTime = Date.now();
-    futureTime = currentTime + 10000;
-    pastTime = currentTime - 10000;
+    currentTime = Date.parse(new Date()) / 1000;
+    futureTime = currentTime + 60;
+    pastTime = currentTime - 60;
   });
 
   describe('[exp] expiration time claim', () => {


### PR DESCRIPTION
The current verifier expects the `exp` time to be in milliseconds but
the spec requires it in seconds:

https://tools.ietf.org/html/rfc7519#section-2

Closes #3