### PR TITLE
Added support for just decoding the Body, when the key is unknown.

### DIFF
--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -84,7 +84,7 @@ class Decoder {
     this.signature = signature;
     this.algorithm = this.getAlgorithm();
 
-    if(_key != null) {
+    if(_key !== null) {
       this.verifySignature(encodedHeader, encodedBody);
     }
     this.verifyClaims();

--- a/lib/decoder.js
+++ b/lib/decoder.js
@@ -84,7 +84,9 @@ class Decoder {
     this.signature = signature;
     this.algorithm = this.getAlgorithm();
 
-    this.verifySignature(encodedHeader, encodedBody);
+    if(_key != null) {
+      this.verifySignature(encodedHeader, encodedBody);
+    }
     this.verifyClaims();
 
     return this._body;

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -26,6 +26,7 @@ describe('JWT', () => {
 
       expect(decoded).toEqual(body);
     });
+    
     it(`can successfully decode a body without knowing the secret for algorithm ${algorithm}`, () => {
       const body = { foo: 'bar' };
       

--- a/tests/index.spec.js
+++ b/tests/index.spec.js
@@ -26,5 +26,12 @@ describe('JWT', () => {
 
       expect(decoded).toEqual(body);
     });
+    it(`can successfully decode a body without knowing the secret for algorithm ${algorithm}`, () => {
+      const body = { foo: 'bar' };
+      
+      const decodedBody = JWT.decode(expectedToken, null, { algorithm });
+      
+      expect(decodedBody).toEqual(body);
+    });
   }
 });


### PR DESCRIPTION
In case you just want to read the content of the JWT, there is now an option to pass null as the key. Then, the verification is simply skipped and you only get the payload.