### PR TITLE
Fixed JWTBody generic type

### DIFF
--- a/lib/decoder.ts
+++ b/lib/decoder.ts
@@ -108,7 +108,7 @@ class Decoder {
     }
     this.verifyClaims();
 
-    return this._body;
+    return this._body as JWTBody<T>;
   }
 }
 

--- a/lib/decoder.ts
+++ b/lib/decoder.ts
@@ -24,9 +24,9 @@ const parse = (encodedString: string) =>
 const sign = (body: string, algorithm: AlgorithmFunction) =>
   urlEncodeBase64(algorithm(body, _key).toString(Base64));
 
-class Decoder {
+class Decoder<T> {
   _header: JWTHeader;
-  _body: JWTBody;
+  _body: JWTBody<T>;
   options: DecodingOptions;
   algorithm: 'none' | AlgorithmFunction;
   signature: string;
@@ -87,7 +87,7 @@ class Decoder {
     Verifier.verifyAll(this._body, this.options);
   }
 
-  decodeAndVerify<T>(
+  decodeAndVerify(
     token: JWTToken,
     options: DecodingOptions = {}
   ): JWTBody<T> {
@@ -108,7 +108,7 @@ class Decoder {
     }
     this.verifyClaims();
 
-    return this._body as JWTBody<T>;
+    return this._body;
   }
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,7 +16,7 @@ const JWT = {
     return encoder.encodeAndSign();
   },
 
-  decode: <T>(
+  decode: <T = Record<string, any>>(
     token: JWTToken,
     key: EncodingKey,
     options: DecodingOptions = {}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -7,6 +7,7 @@ import {
   EncodingOptions,
   DecodingOptions,
   EncodingKey,
+  JWTDefaultBody,
 } from '../types/jwt';
 
 const JWT = {
@@ -16,14 +17,14 @@ const JWT = {
     return encoder.encodeAndSign();
   },
 
-  decode: <T = Record<string, any>>(
+  decode: <T = JWTDefaultBody>(
     token: JWTToken,
     key: EncodingKey,
     options: DecodingOptions = {}
   ): JWTBody<T> => {
-    const decoder = new Decoder(key);
+    const decoder = new Decoder<T>(key);
 
-    return decoder.decodeAndVerify<T>(token, options);
+    return decoder.decodeAndVerify(token, options);
   },
 };
 

--- a/lib/verifier.ts
+++ b/lib/verifier.ts
@@ -12,21 +12,8 @@ const claims = [
   Claims.AUD,
 ];
 
-const parseToNumber = (value?: string | number) => {
-  if(typeof(value) === 'number') {
-    return value;
-  } else if(typeof(value) === 'string') {
-    const parsed = parseInt(value);
-
-    if (isNaN(parsed)) {
-      return null;
-    }
-
-    return parsed;
-  }
-
-  return null;
-}
+const parseToNumber = (value?: string | number) =>
+  value ? parseInt(value.toString()) || undefined : undefined;
 
 class Verifier {
   body: JWTBody;

--- a/lib/verifier.ts
+++ b/lib/verifier.ts
@@ -12,8 +12,21 @@ const claims = [
   Claims.AUD,
 ];
 
-const parseToNumber = (value?: string) =>
-  value ? parseInt(value) || null : null;
+const parseToNumber = (value?: string | number) => {
+  if(typeof(value) === 'number') {
+    return value;
+  } else if(typeof(value) === 'string') {
+    const parsed = parseInt(value);
+
+    if (isNaN(parsed)) {
+      return null;
+    }
+
+    return parsed;
+  }
+
+  return null;
+}
 
 class Verifier {
   body: JWTBody;

--- a/specs/decoder.spec.ts
+++ b/specs/decoder.spec.ts
@@ -81,12 +81,14 @@ describe('Decoder', () => {
     });
 
     describe('with generic types', () => {
+      type TestBodyType = Record<string, number>;
+
+      const typedDecoder = new Decoder<TestBodyType>(key);
       const body = { number: 42 };
       const token = generate(body);
 
       it('accepts the generic type and returns the body', () => {
-        type TestBodyType = Record<string, number>;
-        const actual = decoder.decodeAndVerify<TestBodyType>(token);
+        const actual = typedDecoder.decodeAndVerify(token);
 
         expect(actual).toEqual(body);
       });

--- a/types/jwt.ts
+++ b/types/jwt.ts
@@ -10,7 +10,8 @@ export type JWTStandardClaims = {
   jti?: string;
 }
 
-export type JWTBody<T = Record<string, any>> = T & JWTStandardClaims;
+export type JWTDefaultBody = Record<string, any>;
+export type JWTBody<T = JWTDefaultBody> = T & JWTStandardClaims;
 
 export type JWTToken = string;
 

--- a/types/jwt.ts
+++ b/types/jwt.ts
@@ -1,6 +1,16 @@
 import { SupportedAlgorithms } from './algorithms';
 
-export type JWTBody<T = any> = Record<string, T>;
+export type JWTStandardClaims = {
+  iss?: string;
+  sub?: string;
+  aud?: string[] | string;
+  exp?: number;
+  nbf?: number;
+  iat?: number;
+  jti?: string;
+}
+
+export type JWTBody<T = Record<string, any>> = T & JWTStandardClaims;
 
 export type JWTToken = string;
 


### PR DESCRIPTION
This PR fixes #37.

Standard claims set was taken from jwt-decode, which should be up to date with the JWT standard, but didn't double check.

Also changed parseToNumber function.
- JWT body fields such as exp are numbers, not number strings (at least in most implementations). To still allow number strings in these fields and not potentially break any existing implementations, the function is still called, but I did change the function signature.
- parseToNumber function would return null, if the input to the function is '0' or 0. Now, it would return 0. I know that exp and similar fields shouldn't really ever have the value of 0, but maybe in the future this function will be also used elsewhere.
- JavaScript parseInt function already works with number values, but TypeScript complains when trying to pass a number to that function. Therefore, I have added a number type check to satisfy TypeScript.
- This function will produce the same output as before in all scenarios, except when '0' or 0 is passed in as input, therefore no breaking changes are introduced.
