### PR TITLE
Support all header claims from JWT 7515 Spec

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,14 +4,14 @@ import Decoder from './decoder';
 import {
   JWTBody,
   JWTToken,
-  EncodingOptions,
+  HeaderOptions,
   DecodingOptions,
   EncodingKey,
   JWTDefaultBody,
 } from '../types/jwt';
 
 const JWT = {
-  encode: (body: JWTBody, key: EncodingKey, options: EncodingOptions = {}) => {
+  encode: (body: JWTBody, key: EncodingKey, options: HeaderOptions = {}) => {
     const encoder = new Encoder(body, key, options);
 
     return encoder.encodeAndSign();

--- a/specs/encoder.spec.ts
+++ b/specs/encoder.spec.ts
@@ -33,6 +33,38 @@ describe('Encoder', () => {
 
       expect(actual).toEqual(expected);
     });
+
+    it('builds all headers for JWT', () => {
+      const jwt = new Encoder(body, key, {
+        algorithm: SupportedAlgorithms.HS512,
+        jku: 'https://example.com/jku',
+        jwk: 'https://example.com/jwk',
+        kid: 'key-id',
+        x5u: 'https://example.com/x5u',
+        x5c: 'https://example.com/x5c',
+        x5t: 'x5t',
+        'x5t#S256': 'x5t#S256',
+        cty: 'cty',
+        crit: ['crit'],
+      });
+
+      const actual = jwt.buildHeader();
+      const expected = {
+        alg: 'HS512',
+        typ: 'JWT',
+        jku: 'https://example.com/jku',
+        jwk: 'https://example.com/jwk',
+        kid: 'key-id',
+        x5u: 'https://example.com/x5u',
+        x5c: 'https://example.com/x5c',
+        x5t: 'x5t',
+        'x5t#S256': 'x5t#S256',
+        cty: 'cty',
+        crit: ['crit'],
+      };
+
+      expect(actual).toEqual(expected);
+    });
   });
 
   describe('#encodeAndSign with algorithm', () => {

--- a/specs/test-helper.ts
+++ b/specs/test-helper.ts
@@ -1,10 +1,10 @@
 import Encoder from '../lib/encoder';
-import { EncodingOptions, JWTBody } from '../types/jwt';
+import { HeaderOptions, JWTBody } from '../types/jwt';
 
 export const key = 'shh';
 export const body = { foo: 'bar' };
 
-export const generate = (body: JWTBody, opts: EncodingOptions = {}) => {
-  const encoder = new Encoder(body, key, opts);
+export const generate = (body: JWTBody, header: HeaderOptions = {}) => {
+  const encoder = new Encoder(body, key, header);
   return encoder.encodeAndSign();
 };

--- a/types/jwt.ts
+++ b/types/jwt.ts
@@ -8,23 +8,42 @@ export type JWTStandardClaims = {
   nbf?: number;
   iat?: number;
   jti?: string;
-}
+};
 
 export type JWTDefaultBody = Record<string, any>;
 export type JWTBody<T = JWTDefaultBody> = T & JWTStandardClaims;
 
 export type JWTToken = string;
 
-export type JWTHeader = {
-  alg: EncodingOptions['algorithm'];
-  typ: string;
-};
-
-export type EncodingOptions = {
+export type HeaderOptions = {
   algorithm?: SupportedAlgorithms;
+  alg?: SupportedAlgorithms;
+  jku?: string;
+  jwk?: string;
+  kid?: string;
+  x5u?: string;
+  x5c?: string;
+  x5t?: string;
+  ['x5t#S256']?: string;
+  cty?: string;
+  crit?: string[];
 };
 
-export type DecodingOptions = EncodingOptions & {
+export type JWTHeader = {
+  alg: HeaderOptions['algorithm'];
+  typ: string;
+  jku?: string;
+  jwk?: string;
+  kid?: string;
+  x5u?: string;
+  x5c?: string;
+  x5t?: string;
+  ['x5t#S256']?: string;
+  cty?: string;
+  crit?: string[];
+};
+
+export type DecodingOptions = {
   exp?: number;
   nbf?: number;
   iat?: number;


### PR DESCRIPTION
Support all optional header claims from the 7515 spec: https://www.rfc-editor.org/rfc/rfc7515#section-4.1
Allow these to be set using the existing API.

Although the newer [7519](https://datatracker.ietf.org/doc/html/rfc7519#section-5) spec does not contain these claims, it makes sense to support them for any users who are using JWTs built under this spec.

Additionally allows the API to accept simply `alg` instead of the custom `algorithm` option as some suers may expect.

The `buildHeader` public method probably should never have been there and now simply returns the `this.header` set in the constructor, but I have left it there with a comment, for backwards compatibility.

In future this can be removed if we bump the major version in order to clean up the API.