### PR TITLE
Support Safe URL Base64 encoding

### DIFF
--- a/lib/decoder.ts
+++ b/lib/decoder.ts
@@ -1,10 +1,10 @@
-import Base64 from "crypto-js/enc-base64";
-import Utf8 from "crypto-js/enc-utf8";
+import Base64 from 'crypto-js/enc-base64';
+import Utf8 from 'crypto-js/enc-utf8';
 
-import Verifier from "./verifier";
-import * as Errors from "./errors";
-import algorithms, { supportedAlgorithms } from "./algorithms";
-import { urlEncodeBase64, urlSafeBase64ToBase64 } from "./helpers";
+import Verifier from './verifier';
+import * as Errors from './errors';
+import algorithms, { supportedAlgorithms } from './algorithms';
+import { urlEncodeBase64, urlSafeBase64ToBase64 } from './helpers';
 
 import {
   EncodingKey,
@@ -12,9 +12,9 @@ import {
   JWTHeader,
   DecodingOptions,
   JWTToken,
-} from "../types/jwt";
+} from '../types/jwt';
 
-type AlgorithmFunction = (typeof algorithms)["HS256"];
+type AlgorithmFunction = (typeof algorithms)['HS256'];
 
 let _key: EncodingKey;
 
@@ -30,7 +30,7 @@ class Decoder<T> {
   _header: JWTHeader;
   _body: JWTBody<T>;
   options: DecodingOptions;
-  algorithm: "none" | AlgorithmFunction;
+  algorithm: 'none' | AlgorithmFunction;
   signature: string;
 
   constructor(key: EncodingKey) {
@@ -60,8 +60,8 @@ class Decoder<T> {
       throw new Errors.AlgorithmMissing();
     }
 
-    if (algorithm === "none") {
-      return "none";
+    if (algorithm === 'none') {
+      return 'none';
     }
 
     if (!~supportedAlgorithms.indexOf(algorithm)) {
@@ -72,7 +72,7 @@ class Decoder<T> {
   }
 
   verifySignature(encodedHeader: string, encodedBody: string) {
-    if (this.algorithm === "none") {
+    if (this.algorithm === 'none') {
       return true;
     }
 
@@ -90,7 +90,7 @@ class Decoder<T> {
   }
 
   decodeAndVerify(token: JWTToken, options: DecodingOptions = {}): JWTBody<T> {
-    const [encodedHeader, encodedBody, signature] = token.toString().split(".");
+    const [encodedHeader, encodedBody, signature] = token.toString().split('.');
 
     if (!encodedHeader || !encodedBody) {
       throw new Errors.InvalidStructure();

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -7,8 +7,11 @@ export const urlEncodeBase64 = (signature: string): string => {
 };
 
 export const urlSafeBase64ToBase64 = (signature) => {
-  if (isUrlSafeBase64(signature))
+  if (isUrlSafeBase64(signature)) {
     return signature.replace(/-/g, '+').replace(/_/g, '/');
+  }
+
+  return signature;
 };
 
 export const isUrlSafeBase64 = (content: string) =>

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,7 +1,15 @@
 export const urlEncodeBase64 = (signature: string): string => {
-  signature = signature.replace(/(=+)$/g, '');
-  signature = signature.replace(/\//g, '_');
-  signature = signature.replace(/\+/g, '-');
+  signature = signature.replace(/(=+)$/g, "");
+  signature = signature.replace(/\//g, "_");
+  signature = signature.replace(/\+/g, "-");
 
   return signature;
 };
+
+export const urlSafeBase64ToBase64 = (signature) => {
+  if (isUrlSafeBase64(signature))
+    return signature.replace(/-/g, "+").replace(/_/g, "/");
+};
+
+export const isUrlSafeBase64 = (content: string) =>
+  /^[A-Za-z0-9_-]*[.=]{0,2}$/.test(content);

--- a/lib/helpers.ts
+++ b/lib/helpers.ts
@@ -1,14 +1,14 @@
 export const urlEncodeBase64 = (signature: string): string => {
-  signature = signature.replace(/(=+)$/g, "");
-  signature = signature.replace(/\//g, "_");
-  signature = signature.replace(/\+/g, "-");
+  signature = signature.replace(/(=+)$/g, '');
+  signature = signature.replace(/\//g, '_');
+  signature = signature.replace(/\+/g, '-');
 
   return signature;
 };
 
 export const urlSafeBase64ToBase64 = (signature) => {
   if (isUrlSafeBase64(signature))
-    return signature.replace(/-/g, "+").replace(/_/g, "/");
+    return signature.replace(/-/g, '+').replace(/_/g, '/');
 };
 
 export const isUrlSafeBase64 = (content: string) =>

--- a/specs/decoder.spec.ts
+++ b/specs/decoder.spec.ts
@@ -1,16 +1,16 @@
-import Decoder from '../lib/decoder';
-import Verifier from '../lib/verifier';
-import * as Errors from '../lib/errors';
+import Decoder from "../lib/decoder";
+import Verifier from "../lib/verifier";
+import * as Errors from "../lib/errors";
 
-import { key, generate } from './test-helper';
+import { key, generate } from "./test-helper";
 
 const decoder = new Decoder(key);
 
-describe('Decoder', () => {
-  describe('#decodeAndVerify', () => {
-    describe('invalid formats', () => {
-      describe('structure invalid', () => {
-        const inputs = [123, {}, [], '', 'foo', 'header.'];
+describe("Decoder", () => {
+  describe("#decodeAndVerify", () => {
+    describe("invalid formats", () => {
+      describe("structure invalid", () => {
+        const inputs = [123, {}, [], "", "foo", "header."];
 
         inputs.forEach((input) => {
           it(`throws InvalidStructure error for the input "${input}"`, () => {
@@ -22,16 +22,16 @@ describe('Decoder', () => {
         });
       });
 
-      it('throws InvalidHeader if the header cannot be parsed', () => {
-        const token = 'eyJhbGciOiJmLCJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.';
+      it("throws InvalidHeader if the header cannot be parsed", () => {
+        const token = "eyJhbGciOiJmLCJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.";
 
         expect(() => {
           decoder.decodeAndVerify(token);
         }).toThrow(new Errors.InvalidHeader());
       });
 
-      it('throws InvalidBody if the body cannot be parsed', () => {
-        const token = 'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJmb28iOiAiYmF9.';
+      it("throws InvalidBody if the body cannot be parsed", () => {
+        const token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJmb28iOiAiYmF9.";
 
         expect(() => {
           decoder.decodeAndVerify(token);
@@ -39,7 +39,7 @@ describe('Decoder', () => {
       });
 
       it('throws AlgorithmMissing if "alg" is missing from the header', () => {
-        const token = 'eyJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.';
+        const token = "eyJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.";
 
         expect(() => {
           decoder.decodeAndVerify(token);
@@ -47,7 +47,7 @@ describe('Decoder', () => {
       });
 
       it('throws AlgorithmNotSupported if "alg" is not supported', () => {
-        const token = 'eyJhbGciOiJmb28iLCJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.';
+        const token = "eyJhbGciOiJmb28iLCJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.";
 
         expect(() => {
           decoder.decodeAndVerify(token);
@@ -55,24 +55,24 @@ describe('Decoder', () => {
       });
     });
 
-    describe('verifying signature', () => {
-      const body = { foo: 'bar' };
+    describe("verifying signature", () => {
+      const body = { foo: "bar" };
       const token = generate(body);
 
-      it('verifies the signature successfully', () => {
+      it("verifies the signature successfully", () => {
         const actual = decoder.decodeAndVerify(token);
 
         expect(actual).toEqual(body);
       });
 
-      it('throws if signature is invalid', () => {
+      it("throws if signature is invalid", () => {
         expect(() => {
-          decoder.decodeAndVerify(token + 'XYZ');
+          decoder.decodeAndVerify(token + "XYZ");
         }).toThrow(new Errors.SignatureInvalid());
       });
 
-      it('validates claims', () => {
-        const spy = jest.spyOn(Verifier, 'verifyAll');
+      it("validates claims", () => {
+        const spy = jest.spyOn(Verifier, "verifyAll");
 
         decoder.decodeAndVerify(token);
 
@@ -80,15 +80,56 @@ describe('Decoder', () => {
       });
     });
 
-    describe('with generic types', () => {
+    describe("with generic types", () => {
       type TestBodyType = Record<string, number>;
 
       const typedDecoder = new Decoder<TestBodyType>(key);
       const body = { number: 42 };
       const token = generate(body);
 
-      it('accepts the generic type and returns the body', () => {
+      it("accepts the generic type and returns the body", () => {
         const actual = typedDecoder.decodeAndVerify(token);
+
+        expect(actual).toEqual(body);
+      });
+    });
+
+    describe("with urlBase64 parse", () => {
+      type TestBodyType = Record<string, any>;
+      const typedDecoder = new Decoder<TestBodyType>(key);
+      const body = {
+        code: 1,
+        message: "OK",
+        data: {
+          user: {
+            level_experience_upper_limit: 9999,
+            total_level_experience: "xxx",
+            current_level_process_rate: 0.0996,
+            employer_invite_code: "BQ4W8Q",
+            level_reward_rate: 0.996,
+            id: "*****",
+            invite_code: "EQYUNC",
+            has_transactions: true,
+            level: 3,
+            avatar_url:
+              "https://app-xxxx.x.x-xx.xxx.com/public/development/avatarImage/924e97db-XXX-XX-ABAB-AA33ee9e3ecx.png?imageMogr2/crop/50x50",
+            first_name: "sss",
+            last_name: "ddd",
+            country: "japan",
+            balance: "*****",
+            invitees: 5,
+          },
+          user_token: "*****",
+        },
+      };
+      const token = generate(body);
+
+      it("Return the correct object containing URL-encoded data", () => {
+        const actual = typedDecoder.decodeAndVerify(token);
+
+        console.debug("🐛🐛🐛 ------------------------------🐛🐛🐛");
+        console.debug("🐛🐛🐛 ::: actual:::", actual);
+        console.debug("🐛🐛🐛 ------------------------------🐛🐛🐛");
 
         expect(actual).toEqual(body);
       });

--- a/specs/decoder.spec.ts
+++ b/specs/decoder.spec.ts
@@ -96,38 +96,25 @@ describe('Decoder', () => {
 
     describe('with urlBase64 parse', () => {
       type TestBodyType = Record<string, any>;
-      const typedDecoder = new Decoder<TestBodyType>(key);
+
       const body = {
         code: 1,
         message: 'OK',
+        name: 'JohnDoe',
         data: {
-          user: {
-            level_experience_upper_limit: 9999,
-            total_level_experience: 'xxx',
-            current_level_process_rate: 0.0996,
-            employer_invite_code: 'BQ4W8Q',
-            level_reward_rate: 0.996,
-            id: '*****',
-            invite_code: 'EQYUNC',
-            has_transactions: true,
-            level: 3,
-            avatar_url:
-              'https://app-xxxx.x.x-xx.xxx.com/public/development/avatarImage/924e97db-XXX-XX-ABAB-AA33ee9e3ecx.png?imageMogr2/crop/50x50',
-            first_name: 'sss',
-            last_name: 'ddd',
-            country: 'japan',
-            balance: '*****',
-            invitees: 5,
-          },
-          user_token: '*****',
+          avatar:
+            'https:/test-spec-1.com/avatarImage/ABC123-45ED-678FG.png?image/crop/50x50&params=1',
         },
       };
+      const typedDecoder = new Decoder<TestBodyType>(key);
       const token = generate(body);
 
-      it('Return the correct object containing URL-encoded data', () => {
+      it('returns the correct object containing URL-encoded data', () => {
         const actual = typedDecoder.decodeAndVerify(token);
+
         expect(actual).toEqual(body);
       });
     });
+    
   });
 });

--- a/specs/decoder.spec.ts
+++ b/specs/decoder.spec.ts
@@ -1,16 +1,16 @@
-import Decoder from "../lib/decoder";
-import Verifier from "../lib/verifier";
-import * as Errors from "../lib/errors";
+import Decoder from '../lib/decoder';
+import Verifier from '../lib/verifier';
+import * as Errors from '../lib/errors';
 
-import { key, generate } from "./test-helper";
+import { key, generate } from './test-helper';
 
 const decoder = new Decoder(key);
 
-describe("Decoder", () => {
-  describe("#decodeAndVerify", () => {
-    describe("invalid formats", () => {
-      describe("structure invalid", () => {
-        const inputs = [123, {}, [], "", "foo", "header."];
+describe('Decoder', () => {
+  describe('#decodeAndVerify', () => {
+    describe('invalid formats', () => {
+      describe('structure invalid', () => {
+        const inputs = [123, {}, [], '', 'foo', 'header.'];
 
         inputs.forEach((input) => {
           it(`throws InvalidStructure error for the input "${input}"`, () => {
@@ -22,16 +22,16 @@ describe("Decoder", () => {
         });
       });
 
-      it("throws InvalidHeader if the header cannot be parsed", () => {
-        const token = "eyJhbGciOiJmLCJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.";
+      it('throws InvalidHeader if the header cannot be parsed', () => {
+        const token = 'eyJhbGciOiJmLCJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.';
 
         expect(() => {
           decoder.decodeAndVerify(token);
         }).toThrow(new Errors.InvalidHeader());
       });
 
-      it("throws InvalidBody if the body cannot be parsed", () => {
-        const token = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJmb28iOiAiYmF9.";
+      it('throws InvalidBody if the body cannot be parsed', () => {
+        const token = 'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJmb28iOiAiYmF9.';
 
         expect(() => {
           decoder.decodeAndVerify(token);
@@ -39,7 +39,7 @@ describe("Decoder", () => {
       });
 
       it('throws AlgorithmMissing if "alg" is missing from the header', () => {
-        const token = "eyJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.";
+        const token = 'eyJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.';
 
         expect(() => {
           decoder.decodeAndVerify(token);
@@ -47,7 +47,7 @@ describe("Decoder", () => {
       });
 
       it('throws AlgorithmNotSupported if "alg" is not supported', () => {
-        const token = "eyJhbGciOiJmb28iLCJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.";
+        const token = 'eyJhbGciOiJmb28iLCJ0eXAiOiJKV1QifQ.eyJmb28iOiJiYXIifQ.';
 
         expect(() => {
           decoder.decodeAndVerify(token);
@@ -55,24 +55,24 @@ describe("Decoder", () => {
       });
     });
 
-    describe("verifying signature", () => {
-      const body = { foo: "bar" };
+    describe('verifying signature', () => {
+      const body = { foo: 'bar' };
       const token = generate(body);
 
-      it("verifies the signature successfully", () => {
+      it('verifies the signature successfully', () => {
         const actual = decoder.decodeAndVerify(token);
 
         expect(actual).toEqual(body);
       });
 
-      it("throws if signature is invalid", () => {
+      it('throws if signature is invalid', () => {
         expect(() => {
-          decoder.decodeAndVerify(token + "XYZ");
+          decoder.decodeAndVerify(token + 'XYZ');
         }).toThrow(new Errors.SignatureInvalid());
       });
 
-      it("validates claims", () => {
-        const spy = jest.spyOn(Verifier, "verifyAll");
+      it('validates claims', () => {
+        const spy = jest.spyOn(Verifier, 'verifyAll');
 
         decoder.decodeAndVerify(token);
 
@@ -80,57 +80,52 @@ describe("Decoder", () => {
       });
     });
 
-    describe("with generic types", () => {
+    describe('with generic types', () => {
       type TestBodyType = Record<string, number>;
 
       const typedDecoder = new Decoder<TestBodyType>(key);
       const body = { number: 42 };
       const token = generate(body);
 
-      it("accepts the generic type and returns the body", () => {
+      it('accepts the generic type and returns the body', () => {
         const actual = typedDecoder.decodeAndVerify(token);
 
         expect(actual).toEqual(body);
       });
     });
 
-    describe("with urlBase64 parse", () => {
+    describe('with urlBase64 parse', () => {
       type TestBodyType = Record<string, any>;
       const typedDecoder = new Decoder<TestBodyType>(key);
       const body = {
         code: 1,
-        message: "OK",
+        message: 'OK',
         data: {
           user: {
             level_experience_upper_limit: 9999,
-            total_level_experience: "xxx",
+            total_level_experience: 'xxx',
             current_level_process_rate: 0.0996,
-            employer_invite_code: "BQ4W8Q",
+            employer_invite_code: 'BQ4W8Q',
             level_reward_rate: 0.996,
-            id: "*****",
-            invite_code: "EQYUNC",
+            id: '*****',
+            invite_code: 'EQYUNC',
             has_transactions: true,
             level: 3,
             avatar_url:
-              "https://app-xxxx.x.x-xx.xxx.com/public/development/avatarImage/924e97db-XXX-XX-ABAB-AA33ee9e3ecx.png?imageMogr2/crop/50x50",
-            first_name: "sss",
-            last_name: "ddd",
-            country: "japan",
-            balance: "*****",
+              'https://app-xxxx.x.x-xx.xxx.com/public/development/avatarImage/924e97db-XXX-XX-ABAB-AA33ee9e3ecx.png?imageMogr2/crop/50x50',
+            first_name: 'sss',
+            last_name: 'ddd',
+            country: 'japan',
+            balance: '*****',
             invitees: 5,
           },
-          user_token: "*****",
+          user_token: '*****',
         },
       };
       const token = generate(body);
 
-      it("Return the correct object containing URL-encoded data", () => {
+      it('Return the correct object containing URL-encoded data', () => {
         const actual = typedDecoder.decodeAndVerify(token);
-
-        console.debug("🐛🐛🐛 ------------------------------🐛🐛🐛");
-        console.debug("🐛🐛🐛 ::: actual:::", actual);
-        console.debug("🐛🐛🐛 ------------------------------🐛🐛🐛");
-
         expect(actual).toEqual(body);
       });
     });


### PR DESCRIPTION
# Description

This is an issue I encountered during a project while collaborating with my colleagues on encryption and decryption with the server.

When our JWT contains a complex URL object, I encountered an error during decoding: `enc_base64_1.default.parse(encodedString).toString(enc_utf8_1.default).`
After debugging the code, I discovered that the error occurred during the parse stage.



For example:
`https://xxx.com/a-b-cdef-gg/12-32s-ggg/ABCE-111.png?AXSD/50x50`
becomes:
`https://xxx.com/a-b-cdef-gg/12-32s-ggg/ABCE-111.pngAXSD/50x50.`

This issue arises from the following code:
```ts
encodedString.replace(/[\x00-\x1F\x7F]/g, '');
```
Additionally, if I remove control characters, the ? in the URL parameter is also removed. 

I resolved this problem by adding a safeUrlBase64To64 method. After testing, everything works fine.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

在 specs/decoder.spec.ts 文件中我增加了 

- [X] Test `with urlBase64 parse`


**Test Configuration**: 
* Firmware version: 1.8.0
* Hardware: MacOs 15.2 Beta  & IOS 18.0
* Toolchain: pnpm 
* SDK: @expo52

# Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
